### PR TITLE
Update Dockerfile so python logs to docker logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ ADD GoBridge.py .
 ADD config.ini .
 
 EXPOSE 2500
-CMD [ "python", "./GoBridge.py" ]
+CMD [ "python","-u", "./GoBridge.py" ]


### PR DESCRIPTION
adding -u means python runs in unbuffered mode and hence logs to `docker logs gobridge`.

small change.